### PR TITLE
CSS validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "dependencies": {
     "brace": "^0.5.1",
     "browserify": "^10.2.4",
-    "csslint": "^0.10.0",
+    "css": "^2.2.1",
     "htmllint": "^0.2.4",
     "jscs": "1.13.1",
     "jshint": "^2.8.0",
     "node-static": "^0.7.6",
+    "PrettyCSS": "^0.3.10",
     "react": "^0.13.3",
     "reactify": "^1.1.1",
     "watchify": "^3.2.3"

--- a/src/validations/css.js
+++ b/src/validations/css.js
@@ -1,3 +1,6 @@
-module.exports = function() {
-  return [];
+var validateWithCss = require('./css/css.js');
+var validateWithPrettyCSS = require('./css/prettycss.js');
+
+module.exports = function(source) {
+  return validateWithCss(source).concat(validateWithPrettyCSS(source));
 };

--- a/src/validations/css/css.js
+++ b/src/validations/css/css.js
@@ -1,0 +1,41 @@
+var css = require('css');
+
+var humanErrors = {
+  "missing '}'": function() {
+    return "You have a starting { but no ending } to go with it.";
+  },
+
+  "property missing ':'": function() {
+    return "Put a colon (:) between the property and the value.\nTry: color: red";
+  },
+
+  "selector missing": function() {
+    return "Start every block of CSS with a selector, such as an element name or class name.\nTry: p {\n  color: red;\n}";
+  }
+};
+
+function convertErrorToAnnotation(error) {
+  if (humanErrors.hasOwnProperty(error.reason)) {
+    var message = humanErrors[error.reason](error);
+    return {
+      row: error.line - 1, column: error.column - 1,
+      raw: message,
+      text: message,
+      type: "error"
+    };
+  } else {
+    console.warn("Couldn't find a human description for", error);
+  }
+};
+
+module.exports = function(source) {
+  var result = css.parse(source, {silent: true}).stylesheet;
+  var annotations = [];
+  result.parsingErrors.forEach(function(error) {
+    var annotation = convertErrorToAnnotation(error);
+    if (annotation !== undefined) {
+      annotations.push(annotation);
+    }
+  });
+  return annotations;
+};

--- a/src/validations/css/prettycss.js
+++ b/src/validations/css/prettycss.js
@@ -1,0 +1,62 @@
+var prettyCSS = require('PrettyCSS');
+
+var humanErrors = {
+  "block-expected": function(error) {
+    return "Start a block using { after your selector.\nTry: " + error.token.content + " {";
+  },
+
+  "extra-tokens-after-value": function() {
+    return "Looks like you're missing a semicolon on the line before this one.";
+  },
+
+  "illegal-token-after-combinator": function() {
+    return "After a + or > in a selector, you need to specify the name of another element, class, or ID";
+  },
+
+  "invalid-token": function() {
+    return "This line doesn't look like valid CSS.";
+  },
+
+  "invalid-value": function(error) {
+    return error.token.content + " isn't a meaningful value for this property. Double-check what values you can use here.";
+  },
+
+  "require-value": function(error) {
+    return "Put a value for " + error.token.content + " after the colon.";
+  },
+
+  "selector-expected": function() {
+    return "Use a comma to separate multiple tag names, classes, or IDs.";
+  },
+
+  "unknown-property": function(error) {
+    return error.token.content + " isn't a property that CSS understands. Double-check the name of the property that you want to use.";
+  }
+};
+
+function convertErrorToAnnotation(error) {
+  var normalized_code = error.code.split(':')[0];
+  if (error.token !== null && humanErrors.hasOwnProperty(normalized_code)) {
+    var message = humanErrors[normalized_code](error);
+    return {
+      row: error.token.line - 1, column: error.charNum - 1,
+      raw: message,
+      text: message,
+      type: "error"
+    };
+  } else {
+    console.warn("Couldn't find a human description for", error);
+  }
+};
+
+module.exports = function(source) {
+  var result = prettyCSS.parse(source);
+  var annotations = [];
+  result.errors.concat(result.warnings).forEach(function(error) {
+    var annotation = convertErrorToAnnotation(error);
+    if (annotation !== undefined) {
+      annotations.push(annotation);
+    }
+  });
+  return annotations;
+};


### PR DESCRIPTION
Not complete—would like to support many more PrettyCSS warnings, and
there is some good stuff in csslint as well. However better to have the
basic validations in place and move on for now.

N.B. using both `css` and `PrettyCSS` because the former has better/more
specific error catching in a handful of important situations (most
notably when there’s no closing curly brace). Might need to do some
deduplication/prioritization of the errors generated.

Fixes #4