### PR TITLE
Add bulkify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "brace": "^0.5.1",
     "browserify": "^10.2.4",
+    "bulkify": "^1.1.1",
     "css": "^2.2.1",
     "es6-promise": "^2.3.0",
     "htmllint": "^0.2.4",


### PR DESCRIPTION
Needed by htmllint but not specified as a dependency, apparently