### PR TITLE
Add libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Some more stuff that would be good:
 Learnpad uses **React** to manage view state, **Ace** as the code editor, and
 **Browserify** to package the client-side application.
 
-Right now, it includes **htmllint**, **css**, **PrettyCSS", **jshint**, and **jscs** for
+Right now, it includes **htmllint**, **css**, **PrettyCSS**, **jshint**, and **jscs** for
 style checking, although as of now jscs is unused.
 
 The Ace editor has a built-in system for error checking, but it's really hard

--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -9,7 +9,7 @@ require('brace/theme/monokai');
 
 var Editor = React.createClass({
   componentDidMount: function(containerElement) {
-    this.setupEditor(containerElement);
+    this._setupEditor(containerElement);
   },
 
   componentDidUpdate: function(_prevProps, _prevState, _prevContext, containerElement) {
@@ -29,12 +29,20 @@ var Editor = React.createClass({
     return false;
   },
 
-  jumpToLine: function(line, column) {
+  render: function() {
+    return (
+      <div className="editor">
+        {this.props.source}
+      </div>
+    )
+  },
+
+  _jumpToLine: function(line, column) {
     this.editor.moveCursorTo(line, column);
     this.editor.focus();
   },
 
-  setupEditor: function(containerElement) {
+  _setupEditor: function(containerElement) {
     this.editor = ACE.edit(this.getDOMNode());
     var language = this.props.language;
     var session = this.editor.getSession();
@@ -43,14 +51,6 @@ var Editor = React.createClass({
     this.editor.on('change', function() {
       this.props.onChange(this.props.language, this.editor.getValue());
     }.bind(this));
-  },
-
-  render: function() {
-    return (
-      <div className="editor">
-        {this.props.source}
-      </div>
-    )
   }
 });
 

--- a/src/components/output.jsx
+++ b/src/components/output.jsx
@@ -11,11 +11,15 @@ var Output = React.createClass({
 
     if (allValid) {
       return (
-        <Preview {...this.props.sources} />
+        <Preview
+          sources={this.props.sources}
+          enabledLibraries={this.props.enabledLibraries} />
       );
     } else {
       return (
-        <ErrorList {...this.props.errors} onErrorClicked={this.props.onErrorClicked} />
+        <ErrorList
+          {...this.props.errors}
+          onErrorClicked={this.props.onErrorClicked} />
       );
     }
   }

--- a/src/components/preview.jsx
+++ b/src/components/preview.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 var React = require('react');
+var libraries = require('../config').libraries;
 
 var Preview = React.createClass({
   componentDidMount: function() {
@@ -17,7 +18,8 @@ var Preview = React.createClass({
     var iframeHead = iframeDocument.head;
     var iframeBody = iframeDocument.body;
 
-    this.props.enabledLibraries.forEach(function(library) {
+    this.props.enabledLibraries.forEach(function(libraryKey) {
+      var library = libraries[libraryKey];
       var css = library.css;
       var javascript = library.javascript;
       if (css !== undefined) {

--- a/src/components/preview.jsx
+++ b/src/components/preview.jsx
@@ -1,54 +1,52 @@
 "use strict";
 
 var React = require('react');
+var DOMParser = window.DOMParser;
+var parser = new DOMParser();
+
 var libraries = require('../config').libraries;
 
 var Preview = React.createClass({
-  componentDidMount: function() {
-    this.addCssAndJavascript();
+  render: function() {
+    return (
+      <div id="preview">
+        <iframe id="preview-frame" srcDoc={this._generateDocument()} ref="frame" />
+      </div>
+    );
   },
 
-  componentDidUpdate: function() {
-    this.addCssAndJavascript();
-  },
+  _generateDocument: function() {
+    var previewDocument = parser.parseFromString(
+      this.props.sources.html, 'text/html');
 
-  addCssAndJavascript: function() {
-    var iframeElement = React.findDOMNode(this.refs.frame);
-    var iframeDocument = iframeElement.contentWindow.document;
-    var iframeHead = iframeDocument.head;
-    var iframeBody = iframeDocument.body;
+    var previewHead = previewDocument.head;
+    var previewBody = previewDocument.body;
 
     this.props.enabledLibraries.forEach(function(libraryKey) {
       var library = libraries[libraryKey];
       var css = library.css;
       var javascript = library.javascript;
       if (css !== undefined) {
-        var linkTag = iframeDocument.createElement('link');
+        var linkTag = previewDocument.createElement('link');
         linkTag.rel = 'stylesheet';
         linkTag.href = css;
-        iframeHead.appendChild(linkTag);
+        previewHead.appendChild(linkTag);
       }
       if (javascript !== undefined) {
-        var scriptTag = iframeDocument.createElement('script');
+        var scriptTag = previewDocument.createElement('script');
         scriptTag.src = javascript;
-        iframeBody.appendChild(scriptTag);
+        previewBody.appendChild(scriptTag);
       }
     });
 
-    var styleTag = iframeDocument.createElement('style');
-    styleTag.innerText = this.props.sources.css;
-    iframeHead.appendChild(styleTag);
-    var scriptTag = iframeDocument.createElement('script');
-    scriptTag.innerText = this.props.sources.javascript;
-    iframeBody.appendChild(scriptTag);
-  },
+    var styleTag = previewDocument.createElement('style');
+    styleTag.innerHTML = this.props.sources.css;
+    previewHead.appendChild(styleTag);
+    var scriptTag = previewDocument.createElement('script');
+    scriptTag.innerHTML = this.props.sources.javascript;
+    previewBody.appendChild(scriptTag);
 
-  render: function() {
-    return (
-      <div id="preview">
-        <iframe id="preview-frame" srcDoc={this.props.sources.html} ref="frame" />
-      </div>
-    );
+    return previewDocument.documentElement.outerHTML;
   }
 });
 

--- a/src/components/preview.jsx
+++ b/src/components/preview.jsx
@@ -16,18 +16,35 @@ var Preview = React.createClass({
     var iframeDocument = iframeElement.contentWindow.document;
     var iframeHead = iframeDocument.head;
     var iframeBody = iframeDocument.body;
+
+    this.props.enabledLibraries.forEach(function(library) {
+      var css = library.css;
+      var javascript = library.javascript;
+      if (css !== undefined) {
+        var linkTag = iframeDocument.createElement('link');
+        linkTag.rel = 'stylesheet';
+        linkTag.href = css;
+        iframeHead.appendChild(linkTag);
+      }
+      if (javascript !== undefined) {
+        var scriptTag = iframeDocument.createElement('script');
+        scriptTag.src = javascript;
+        iframeBody.appendChild(scriptTag);
+      }
+    });
+
     var styleTag = iframeDocument.createElement('style');
-    styleTag.innerText = this.props.css;
+    styleTag.innerText = this.props.sources.css;
     iframeHead.appendChild(styleTag);
     var scriptTag = iframeDocument.createElement('script');
-    scriptTag.innerText = this.props.javascript;
+    scriptTag.innerText = this.props.sources.javascript;
     iframeBody.appendChild(scriptTag);
   },
 
   render: function() {
     return (
       <div id="preview">
-        <iframe id="preview-frame" srcDoc={this.props.html} ref="frame" />
+        <iframe id="preview-frame" srcDoc={this.props.sources.html} ref="frame" />
       </div>
     );
   }

--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -67,14 +67,14 @@ var Toolbar = React.createClass({
 
 var LibraryPicker = React.createClass({
   render: function() {
-    var libraries = _.map(config.libraries, function(library) {
+    var libraries = _.map(config.libraries, function(library, key) {
       var classNames = ['toolbar-libraryPicker-library'];
-      if (this.props.enabledLibraries.indexOf(library) !== -1) {
+      if (this.props.enabledLibraries.indexOf(key) !== -1) {
         classNames.push('toolbar-libraryPicker-library--enabled');
       }
       return <li
         className={classNames.join(' ')}
-        onClick={this._onLibraryClicked.bind(this, library)}>
+        onClick={this._onLibraryClicked.bind(this, key)}>
 
         {library.name}
       </li>;
@@ -82,8 +82,8 @@ var LibraryPicker = React.createClass({
     return <ul className="toolbar-libraryPicker">{libraries}</ul>;
   },
 
-  _onLibraryClicked: function(library) {
-    this.props.onLibraryToggled(library);
+  _onLibraryClicked: function(libraryKey) {
+    this.props.onLibraryToggled(libraryKey);
   }
 });
 

--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -12,11 +12,11 @@ var Toolbar = React.createClass({
   },
 
   render: function() {
-    var toolbarItemsClasses = ['toolbar-items'];
+    var toolbarItemsClasses = ['toolbar-menu'];
     if (this.state.open) {
-      toolbarItemsClasses.push('toolbar-items--open');
+      toolbarItemsClasses.push('toolbar-menu--open');
     } else {
-      toolbarItemsClasses.push('toolbar-items--closed');
+      toolbarItemsClasses.push('toolbar-menu--closed');
     }
 
     return (
@@ -28,8 +28,10 @@ var Toolbar = React.createClass({
           {this._showHideLabel()}
         </div>
         <ul className={toolbarItemsClasses.join(' ')}>
-          <li className='toolbar-items-item'
-            onClick={this._showLibraryPicker}>
+          <li onClick={this._toggleLibraryPicker}
+            className={this.state.submenu === 'libraries' ?
+              'toolbar-menu-item toolbar-menu-item--active' :
+              'toolbar-menu-item'}>
 
             Libraries
           </li>
@@ -47,8 +49,14 @@ var Toolbar = React.createClass({
     }
   },
 
-  _showLibraryPicker: function() {
-    return this.setState({submenu: 'libraries'});
+  _toggleLibraryPicker: function() {
+    return this.setState(function(oldState) {
+      if (oldState.submenu === 'libraries') {
+        return {submenu: null};
+      } else {
+        return {submenu: 'libraries'};
+      }
+    });
   },
 
   _getSubmenu: function() {
@@ -61,16 +69,22 @@ var Toolbar = React.createClass({
   },
 
   _toggleShowHideState: function() {
-    this.setState({open: !this.state.open});
+    this.setState(function(oldState) {
+      if (oldState.open) {
+        return {open: false, submenu: null};
+      } else {
+        return {open: true};
+      }
+    });
   }
 });
 
 var LibraryPicker = React.createClass({
   render: function() {
     var libraries = _.map(config.libraries, function(library, key) {
-      var classNames = ['toolbar-libraryPicker-library'];
+      var classNames = ['toolbar-menu-item'];
       if (this.props.enabledLibraries.indexOf(key) !== -1) {
-        classNames.push('toolbar-libraryPicker-library--enabled');
+        classNames.push('toolbar-menu-item--active');
       }
       return <li
         className={classNames.join(' ')}
@@ -79,7 +93,7 @@ var LibraryPicker = React.createClass({
         {library.name}
       </li>;
     }.bind(this));
-    return <ul className="toolbar-libraryPicker">{libraries}</ul>;
+    return <ul className="toolbar-menu">{libraries}</ul>;
   },
 
   _onLibraryClicked: function(libraryKey) {

--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -2,6 +2,9 @@
 
 var React = require('react');
 var i18n = require('i18next-client');
+var _ = require('lodash');
+
+var config = require('../config');
 
 var Toolbar = React.createClass({
   getInitialState: function() {
@@ -18,17 +21,25 @@ var Toolbar = React.createClass({
 
     return (
       <div className="toolbar">
-        <div className="toolbar-showHide" onClick={this._toggleShowHideState}>
+        <div
+          className="toolbar-showHide"
+          onClick={this._toggleShowHideState}>
+
           {this._showHideLabel()}
         </div>
         <ul className={toolbarItemsClasses.join(' ')}>
-          <li className='toolbar-items-item'>Add Library</li>
+          <li className='toolbar-items-item'
+            onClick={this._showLibraryPicker}>
+
+            Libraries
+          </li>
         </ul>
+        {this._getSubmenu()}
       </div>
     );
   },
 
-  _showHideLabel() {
+  _showHideLabel: function() {
     if (this.state.open) {
       return i18n.t("toolbar.hide");
     } else {
@@ -36,8 +47,43 @@ var Toolbar = React.createClass({
     }
   },
 
-  _toggleShowHideState() {
+  _showLibraryPicker: function() {
+    return this.setState({submenu: 'libraries'});
+  },
+
+  _getSubmenu: function() {
+    switch(this.state.submenu) {
+      case 'libraries':
+        return <LibraryPicker
+          enabledLibraries={this.props.enabledLibraries}
+          onLibraryToggled={this.props.onLibraryToggled} />;
+    }
+  },
+
+  _toggleShowHideState: function() {
     this.setState({open: !this.state.open});
+  }
+});
+
+var LibraryPicker = React.createClass({
+  render: function() {
+    var libraries = _.map(config.libraries, function(library) {
+      var classNames = ['toolbar-libraryPicker-library'];
+      if (this.props.enabledLibraries.indexOf(library) !== -1) {
+        classNames.push('toolbar-libraryPicker-library--enabled');
+      }
+      return <li
+        className={classNames.join(' ')}
+        onClick={this._onLibraryClicked.bind(this, library)}>
+
+        {library.name}
+      </li>;
+    }.bind(this));
+    return <ul className="toolbar-libraryPicker">{libraries}</ul>;
+  },
+
+  _onLibraryClicked: function(library) {
+    this.props.onLibraryToggled(library);
   }
 });
 

--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -1,0 +1,44 @@
+"use strict";
+
+var React = require('react');
+var i18n = require('i18next-client');
+
+var Toolbar = React.createClass({
+  getInitialState: function() {
+    return {open: false};
+  },
+
+  render: function() {
+    var toolbarItemsClasses = ['toolbar-items'];
+    if (this.state.open) {
+      toolbarItemsClasses.push('toolbar-items--open');
+    } else {
+      toolbarItemsClasses.push('toolbar-items--closed');
+    }
+
+    return (
+      <div className="toolbar">
+        <div className="toolbar-showHide" onClick={this._toggleShowHideState}>
+          {this._showHideLabel()}
+        </div>
+        <ul className={toolbarItemsClasses.join(' ')}>
+          <li className='toolbar-items-item'>Add Library</li>
+        </ul>
+      </div>
+    );
+  },
+
+  _showHideLabel() {
+    if (this.state.open) {
+      return i18n.t("toolbar.hide");
+    } else {
+      return i18n.t("toolbar.show");
+    }
+  },
+
+  _toggleShowHideState() {
+    this.setState({open: !this.state.open});
+  }
+});
+
+module.exports = Toolbar;

--- a/src/components/workspace.jsx
+++ b/src/components/workspace.jsx
@@ -77,14 +77,48 @@ var Workspace = React.createClass({
   render: function() {
     return (
       <div id="workspace">
-        <Toolbar />
-        <Output sources={this.state.sources} errors={this.state.errors} onErrorClicked={this.onErrorClicked} />
+        <Toolbar
+          enabledLibraries={this.state.enabledLibraries}
+          onLibraryToggled={this._onLibraryToggled} />
 
-        <Editor ref="htmlEditor" language="html" source={this.state.sources.html} errors={this.state.errors.html} onChange={this.setSource} />
-        <Editor ref="cssEditor" language="css" source={this.state.sources.css} errors={this.state.errors.css} onChange={this.setSource} />
-        <Editor ref="javascriptEditor" language="javascript" source={this.state.sources.javascript} errors={this.state.errors.javascript} onChange={this.setSource} />
+        <Output
+          sources={this.state.sources}
+          errors={this.state.errors}
+          enabledLibraries={this.state.enabledLibraries}
+          onErrorClicked={this.onErrorClicked} />
+
+        <Editor
+          language="html"
+          source={this.state.sources.html}
+          errors={this.state.errors.html}
+          onChange={this.setSource} />
+
+        <Editor
+          language="css"
+          source={this.state.sources.css}
+          errors={this.state.errors.css}
+          onChange={this.setSource} />
+
+        <Editor
+          language="javascript"
+          source={this.state.sources.javascript}
+          errors={this.state.errors.javascript}
+          onChange={this.setSource} />
       </div>
     )
+  },
+
+  _onLibraryToggled: function(library) {
+    this.setState(function(oldState) {
+      var libraryIndex = oldState.enabledLibraries.indexOf(library);
+      if (libraryIndex !== -1) {
+        return update(oldState, {
+          enabledLibraries: {$splice: [[libraryIndex, 1]]}
+        });
+      } else {
+        return update(oldState, {enabledLibraries: {$push: [library]}});
+      }
+    });
   }
 });
 

--- a/src/components/workspace.jsx
+++ b/src/components/workspace.jsx
@@ -55,7 +55,7 @@ var Workspace = React.createClass({
 
   validateInput: function(language, source) {
     var validate = Validations[language];
-    validate(source).then(function(errors) {
+    validate(source, this.state.enabledLibraries).then(function(errors) {
       var updateCommand = {errors: {}};
       updateCommand.errors[language] = {$set: errors};
       this.setState(function(oldState) {

--- a/src/components/workspace.jsx
+++ b/src/components/workspace.jsx
@@ -14,7 +14,7 @@ var config = require('../config.js');
 var Workspace = React.createClass({
   getInitialState: function() {
     return _.assign(config.defaults, {
-      storageKey: this.generateStorageKey()
+      storageKey: this._generateStorageKey()
     });
   },
 
@@ -35,7 +35,7 @@ var Workspace = React.createClass({
 
     for (var language in nextState.sources) {
       if (this.state.sources[language] !== nextState.sources[language]) {
-        this.validateInput(
+        this._validateInput(
           language,
           nextState.sources[language],
           nextState.enabledLibraries);
@@ -58,36 +58,6 @@ var Workspace = React.createClass({
     }
   },
 
-  setSource: function(language, source) {
-    var updateCommand = {sources: {}};
-    updateCommand.sources[language] = {$set: source};
-
-    this.setState(function(oldState) {
-      return update(oldState, updateCommand);
-    });
-  },
-
-  validateInput: function(language, source, enabledLibraries) {
-    var validate = Validations[language];
-    validate(source, enabledLibraries).then(function(errors) {
-      var updateCommand = {errors: {}};
-      updateCommand.errors[language] = {$set: errors};
-      this.setState(function(oldState) {
-        return update(oldState, updateCommand);
-      });
-    }.bind(this));
-  },
-
-  onErrorClicked: function(language, line, column) {
-    var editor = this.refs[language + 'Editor'];
-    editor.jumpToLine(line, column);
-  },
-
-  generateStorageKey: function() {
-    var date = new Date();
-    return (date.getTime() * 1000 + date.getMilliseconds()).toString();
-  },
-
   render: function() {
     return (
       <div id="workspace">
@@ -99,27 +69,60 @@ var Workspace = React.createClass({
           sources={this.state.sources}
           errors={this.state.errors}
           enabledLibraries={this.state.enabledLibraries}
-          onErrorClicked={this.onErrorClicked} />
+          onErrorClicked={this._onErrorClicked} />
 
         <Editor
+          ref="htmlEditor"
           language="html"
           source={this.state.sources.html}
           errors={this.state.errors.html}
-          onChange={this.setSource} />
+          onChange={this._setSource} />
 
         <Editor
+          ref="cssEditor"
           language="css"
           source={this.state.sources.css}
           errors={this.state.errors.css}
-          onChange={this.setSource} />
+          onChange={this._setSource} />
 
         <Editor
+          ref="javascriptEditor"
           language="javascript"
           source={this.state.sources.javascript}
           errors={this.state.errors.javascript}
-          onChange={this.setSource} />
+          onChange={this._setSource} />
       </div>
     )
+  },
+
+  _setSource: function(language, source) {
+    var updateCommand = {sources: {}};
+    updateCommand.sources[language] = {$set: source};
+
+    this.setState(function(oldState) {
+      return update(oldState, updateCommand);
+    });
+  },
+
+  _validateInput: function(language, source, enabledLibraries) {
+    var validate = Validations[language];
+    validate(source, enabledLibraries).then(function(errors) {
+      var updateCommand = {errors: {}};
+      updateCommand.errors[language] = {$set: errors};
+      this.setState(function(oldState) {
+        return update(oldState, updateCommand);
+      });
+    }.bind(this));
+  },
+
+  _onErrorClicked: function(language, line, column) {
+    var editor = this.refs[language + 'Editor'];
+    editor._jumpToLine(line, column);
+  },
+
+  _generateStorageKey: function() {
+    var date = new Date();
+    return (date.getTime() * 1000 + date.getMilliseconds()).toString();
   },
 
   _onLibraryToggled: function(libraryKey) {

--- a/src/components/workspace.jsx
+++ b/src/components/workspace.jsx
@@ -65,32 +65,34 @@ var Workspace = React.createClass({
           enabledLibraries={this.state.enabledLibraries}
           onLibraryToggled={this._onLibraryToggled} />
 
-        <Output
-          sources={this.state.sources}
-          errors={this.state.errors}
-          enabledLibraries={this.state.enabledLibraries}
-          onErrorClicked={this._onErrorClicked} />
+        <div className="environment">
+          <Output
+            sources={this.state.sources}
+            errors={this.state.errors}
+            enabledLibraries={this.state.enabledLibraries}
+            onErrorClicked={this._onErrorClicked} />
 
-        <Editor
-          ref="htmlEditor"
-          language="html"
-          source={this.state.sources.html}
-          errors={this.state.errors.html}
-          onChange={this._setSource} />
+          <Editor
+            ref="htmlEditor"
+            language="html"
+            source={this.state.sources.html}
+            errors={this.state.errors.html}
+            onChange={this._setSource} />
 
-        <Editor
-          ref="cssEditor"
-          language="css"
-          source={this.state.sources.css}
-          errors={this.state.errors.css}
-          onChange={this._setSource} />
+          <Editor
+            ref="cssEditor"
+            language="css"
+            source={this.state.sources.css}
+            errors={this.state.errors.css}
+            onChange={this._setSource} />
 
-        <Editor
-          ref="javascriptEditor"
-          language="javascript"
-          source={this.state.sources.javascript}
-          errors={this.state.errors.javascript}
-          onChange={this._setSource} />
+          <Editor
+            ref="javascriptEditor"
+            language="javascript"
+            source={this.state.sources.javascript}
+            errors={this.state.errors.javascript}
+            onChange={this._setSource} />
+        </div>
       </div>
     )
   },

--- a/src/components/workspace.jsx
+++ b/src/components/workspace.jsx
@@ -6,6 +6,7 @@ var _ = require('lodash');
 
 var Editor = require('./editor.jsx');
 var Output = require('./output.jsx');
+var Toolbar = require('./toolbar.jsx');
 var Validations = require('../validations');
 var Storage = require('../services/storage');
 var config = require('../config.js');
@@ -76,6 +77,7 @@ var Workspace = React.createClass({
   render: function() {
     return (
       <div id="workspace">
+        <Toolbar />
         <Output sources={this.state.sources} errors={this.state.errors} onErrorClicked={this.onErrorClicked} />
 
         <Editor ref="htmlEditor" language="html" source={this.state.sources.html} errors={this.state.errors.html} onChange={this.setSource} />

--- a/src/config.js
+++ b/src/config.js
@@ -15,50 +15,50 @@ module.exports = {
     enabledLibraries: []
   },
 
-  libraries: [
-    {
+  libraries: {
+    jquery: {
       name: "jQuery",
       javascript: "https://code.jquery.com/jquery-2.1.4.js",
       validations: {javascript: {jquery: {$set: true}}}
     },
-    {
+    lodash: {
       name: "lodash",
       javascript: "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.1/lodash.js",
       validations: {javascript: {predef: {$push: ['_']}}}
     },
-    {
+    underscore: {
       name: "Underscore.js",
       javascript: "https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore.js",
       validations: {javascript: {predef: {$push: ['_']}}}
     },
-    {
+    angular: {
       name: "AngularJS",
       javascript: "https://code.angularjs.org/1.4.4/angular.js",
       validations: {javascript: {predef: {$push: ['angular']}}}
     },
-    {
+    react: {
       name: "React",
       javascript: "https://fb.me/react-0.13.3.js",
       validations: {javascript: {predef: {$push: ['React']}}}
     },
-    {
+    ember: {
       name: "Ember.js",
       javascript: "http://builds.emberjs.com/release/ember.js",
       validations: {javascript: {predef: {$push: ['Ember']}}}
     },
-    {
+    bootstrap: {
       name: "Bootstrap",
       css: "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css",
       javascript: "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"
     },
-    {
+    foundation: {
       name: "Foundation",
       css: "https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/css/foundation.css",
       javascript: "https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/js/foundation.js"
     },
-    {
+    normalize: {
       name: "normalize.css",
       css:"https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css"
     }
-  ]
+  }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -18,19 +18,23 @@ module.exports = {
   libraries: [
     {
       name: "jQuery",
-      javascript: "https://code.jquery.com/jquery-2.1.4.js"
+      javascript: "https://code.jquery.com/jquery-2.1.4.js",
+      validations: {javascript: {jquery: {$set: true}}}
     },
     {
       name: "AngularJS",
-      javascript: "https://code.angularjs.org/1.4.4/angular.js"
+      javascript: "https://code.angularjs.org/1.4.4/angular.js",
+      validations: {javascript: {predef: {$push: ['angular']}}}
     },
     {
       name: "React",
-      javascript: "https://fb.me/react-0.13.3.js"
+      javascript: "https://fb.me/react-0.13.3.js",
+      validations: {javascript: {predef: {$push: ['React']}}}
     },
     {
       name: "Ember.js",
-      javascript: "http://builds.emberjs.com/release/ember.js"
+      javascript: "http://builds.emberjs.com/release/ember.js",
+      validations: {javascript: {predef: {$push: ['Ember']}}}
     },
     {
       name: "Bootstrap",

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,40 @@ module.exports = {
       html: [],
       css: [],
       javascript: []
+    },
+    enabledLibraries: []
+  },
+
+  libraries: [
+    {
+      name: "jQuery",
+      javascript: "https://code.jquery.com/jquery-2.1.4.js"
+    },
+    {
+      name: "AngularJS",
+      javascript: "https://code.angularjs.org/1.4.4/angular.js"
+    },
+    {
+      name: "React",
+      javascript: "https://fb.me/react-0.13.3.js"
+    },
+    {
+      name: "Ember.js",
+      javascript: "http://builds.emberjs.com/release/ember.js"
+    },
+    {
+      name: "Bootstrap",
+      css: "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css",
+      javascript: "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"
+    },
+    {
+      name: "Foundation",
+      css: "https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/css/foundation.css",
+      javascript: "https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.2/js/foundation.js"
+    },
+    {
+      name: "normalize.css",
+      css:"https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css"
     }
-  }
+  ]
 }

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,16 @@ module.exports = {
       validations: {javascript: {jquery: {$set: true}}}
     },
     {
+      name: "lodash",
+      javascript: "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.1/lodash.js",
+      validations: {javascript: {predef: {$push: ['_']}}}
+    },
+    {
+      name: "Underscore.js",
+      javascript: "https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore.js",
+      validations: {javascript: {predef: {$push: ['_']}}}
+    },
+    {
       name: "AngularJS",
       javascript: "https://code.angularjs.org/1.4.4/angular.js",
       validations: {javascript: {predef: {$push: ['angular']}}}

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,18 +1,18 @@
 var localforage = require('localforage');
 
-var storageVersion = 1;
+var storageVersion = 2;
 
 var fullKeyFor = function(key) {
-  return storageVersion + '/workspaces/' + key;
+  return 'workspaces/' + key;
 };
 
 var Storage = {
   load: function() {
     return localforage.getItem('lastKey').then(function(key) {
       if (key !== null) {
-        return localforage.getItem(fullKeyFor(key)).then(function(data) {
-          if (data !== null) {
-            return {key: key, data: data};
+        return localforage.getItem(fullKeyFor(key)).then(function(payload) {
+          if (payload !== null) {
+            return payload;
           }
         });
       }
@@ -20,8 +20,16 @@ var Storage = {
   },
 
   save: function(key, data) {
-    localforage.setItem('lastKey', key)
-    localforage.setItem(fullKeyFor(key), data)
+    localforage.setItem('lastKey', key);
+    localforage.setItem(
+      fullKeyFor(key),
+      {
+        key: key,
+        storageVersion: storageVersion,
+        data: data
+      }
+    );
+
     return data;
   }
 };

--- a/src/validations/javascript.js
+++ b/src/validations/javascript.js
@@ -84,11 +84,11 @@ var humanErrors = {
   },
 
   "W117": function(error) {
-    i18n.t("errors.javascript.declare-variable", { variable: error.a });
+    return i18n.t("errors.javascript.declare-variable", { variable: error.a });
   },
 
   "W123": function(error) {
-    i18n.t("errors.javascript.duplicated-declaration", { variable: error.a });
+    return i18n.t("errors.javascript.duplicated-declaration", { variable: error.a });
   }
 };
 

--- a/src/validations/javascript.js
+++ b/src/validations/javascript.js
@@ -1,6 +1,7 @@
 var i18n = require('i18next-client');
 var JSHINT = require('jshint').JSHINT;
 var Promise = require('es6-promise').Promise;
+var update = require('react/addons').addons.update;
 
 var jshintrc = {
   browser: true,
@@ -9,6 +10,7 @@ var jshintrc = {
   eqeqeq: true,
   latedef: true,
   nonew: true,
+  predef: [],
   shadow: "outer",
   undef: true,
   unused: true
@@ -103,8 +105,16 @@ function convertErrorToAnnotation(error) {
   }
 }
 
-module.exports = function(source) {
-  JSHINT(source, jshintrc);
+module.exports = function(source, libraries) {
+  var config = jshintrc;
+  libraries.forEach(function(library) {
+    if (library.validations !== undefined &&
+        library.validations.javascript !== undefined) {
+      config = update(config, library.validations.javascript);
+    }
+  });
+
+  JSHINT(source, config);
   var data = JSHINT.data();
   var annotations = [];
   var annotatedLines = [];

--- a/src/validations/javascript.js
+++ b/src/validations/javascript.js
@@ -2,6 +2,7 @@ var i18n = require('i18next-client');
 var JSHINT = require('jshint').JSHINT;
 var Promise = require('es6-promise').Promise;
 var update = require('react/addons').addons.update;
+var libraries = require('../config').libraries;
 
 var jshintrc = {
   browser: true,
@@ -105,9 +106,11 @@ function convertErrorToAnnotation(error) {
   }
 }
 
-module.exports = function(source, libraries) {
+module.exports = function(source, enabledLibraries) {
   var config = jshintrc;
-  libraries.forEach(function(library) {
+  enabledLibraries.forEach(function(libraryKey) {
+    var library = libraries[libraryKey];
+
     if (library.validations !== undefined &&
         library.validations.javascript !== undefined) {
       config = update(config, library.validations.javascript);

--- a/static/application.css
+++ b/static/application.css
@@ -2,6 +2,15 @@ body {
   font-family: Verdana;
 }
 
+.toolbar-showHide {
+  height: 1rem;
+  padding: 0.5rem 0;
+  background-color: rgb(220, 220, 220);
+  font-weight: bold;
+  text-align: center;
+  cursor: pointer;
+}
+
 .editor {
   box-sizing: border-box;
   border-right: 2px solid gray;

--- a/static/application.css
+++ b/static/application.css
@@ -3,6 +3,7 @@ body {
 }
 
 .editor {
+  box-sizing: border-box;
   border-right: 2px solid gray;
   border-bottom: 2px solid gray;
   width: 50%;
@@ -15,7 +16,7 @@ body {
 
 #preview {
   float: right;
-  width: 49%; /*FIXME*/
+  width: 50%;
   height: 100%;
   position: relative;
 }
@@ -28,7 +29,7 @@ body {
 
 .errorList {
   float: right;
-  width: 49%; /*FIXME*/
+  width: 50%;
   height: 100%;
   position: relative;
   overflow: scroll;

--- a/static/application.css
+++ b/static/application.css
@@ -60,5 +60,8 @@ body {
 
 .toolbar-items--open {
   display: block;
-  min-height: 50%;
+}
+
+.toolbar-libraryPicker-library--enabled {
+  font-weight: bold;
 }

--- a/static/application.css
+++ b/static/application.css
@@ -2,6 +2,11 @@ body {
   font-family: Verdana;
 }
 
+.toolbar {
+  border-bottom: 1px solid darkgray;
+  overflow: hidden;
+}
+
 .toolbar-showHide {
   height: 1rem;
   padding: 0.5rem 0;
@@ -9,6 +14,43 @@ body {
   font-weight: bold;
   text-align: center;
   cursor: pointer;
+}
+
+.toolbar-items {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  width: 50%;
+  float: left;
+}
+
+.toolbar-items-item {
+  cursor: pointer;
+  border-radius: 3px;
+  border: 1px solid gray;
+  padding: 0.5em;
+  margin: 1em;
+  font-weight: bold;
+}
+
+.toolbar-items-item:hover, .toolbar-items-item--active {
+  background-color: lightblue;
+}
+
+.toolbar-items--closed {
+  display: none;
+}
+
+.toolbar-items--open {
+  display: block;
+}
+
+.toolbar-libraryPicker-library--enabled {
+  font-weight: bold;
+}
+
+.environment {
+  clear: left;
 }
 
 .editor {
@@ -62,16 +104,4 @@ body {
   padding: 0.5rem;
   background-color: #ffe6e6;
   cursor: pointer;
-}
-
-.toolbar-items--closed {
-  display: none;
-}
-
-.toolbar-items--open {
-  display: block;
-}
-
-.toolbar-libraryPicker-library--enabled {
-  font-weight: bold;
 }

--- a/static/application.css
+++ b/static/application.css
@@ -16,7 +16,7 @@ body {
   cursor: pointer;
 }
 
-.toolbar-items {
+.toolbar-menu {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -24,29 +24,28 @@ body {
   float: left;
 }
 
-.toolbar-items-item {
+.toolbar-menu-item {
   cursor: pointer;
   border-radius: 3px;
   border: 1px solid gray;
   padding: 0.5em;
   margin: 1em;
-  font-weight: bold;
 }
 
-.toolbar-items-item:hover, .toolbar-items-item--active {
+.toolbar-menu-item:hover, .toolbar-menu-item--active {
   background-color: lightblue;
 }
 
-.toolbar-items--closed {
+.toolbar-menu-item--active {
+  font-weight: bold;
+}
+
+.toolbar-menu--closed {
   display: none;
 }
 
-.toolbar-items--open {
+.toolbar-menu--open {
   display: block;
-}
-
-.toolbar-libraryPicker-library--enabled {
-  font-weight: bold;
 }
 
 .environment {

--- a/static/application.css
+++ b/static/application.css
@@ -53,3 +53,12 @@ body {
   background-color: #ffe6e6;
   cursor: pointer;
 }
+
+.toolbar-items--closed {
+  display: none;
+}
+
+.toolbar-items--open {
+  display: block;
+  min-height: 50%;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
     <link rel="stylesheet" href="/application.css">
   </head>
   <body>

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -1,4 +1,8 @@
 {
+  "toolbar": {
+    "show": "Show Tools",
+    "hide": "Hide Tools"
+  },
   "errors": {
     "undefined-description": "Couldn't find a human description for",
     "notice": "You have __amount__ errors in your __language__!",


### PR DESCRIPTION
Possible to toggle libraries on and off and have them included in the page markup.

To do:

- [x] Update validation configuration appropriately (e.g. `$` should be an allowed global iff you have jQuery enabled)
- [x] Persist library choices along with sources
- [x] Fix partial-preview bug (which is even worse now)
- [x] Make toolbar look reasonable

Follow ups:

- [ ] Add *additional* validators (e.g. `bootlint`) where appropriate
- [ ] Switch languages appropriately (e.g. JSX if you’re using React)
- [ ] “Conflict” warnings? (e.g. you probably shouldn’t use Angular and React together)