### PR TITLE
Wait for project to finish saving before updating key list

### DIFF
--- a/src/services/Storage.js
+++ b/src/services/Storage.js
@@ -33,21 +33,21 @@ var Storage = {
   save: function(data) {
     var key = data.projectKey;
 
-    localforage.getItem('allKeys').then(function(oldKeys) {
-      if (oldKeys === null || oldKeys[oldKeys.length - 1] !== key) {
-        var keys = lodash.without(oldKeys || [], key);
-        keys.unshift(key);
-        localforage.setItem('allKeys', keys);
-      }
-    });
-
     localforage.setItem(
       fullKeyFor(key),
       lodash.extend({
         storageVersion: storageVersion,
         updatedAt: new Date(),
       }, data)
-    );
+    ).then(function() {
+      localforage.getItem('allKeys').then(function(oldKeys) {
+        if (oldKeys === null || oldKeys[oldKeys.length - 1] !== key) {
+          var keys = lodash.without(oldKeys || [], key);
+          keys.unshift(key);
+          localforage.setItem('allKeys', keys);
+        }
+      });
+    });
 
     return data;
   },


### PR DESCRIPTION
Prevents storage from being in an invalid state where there is a key in the list referring to a project that is not there.